### PR TITLE
Close ZipArchive after extraction when running ckfinder:download

### DIFF
--- a/Command/CKFinderDownloadCommand.php
+++ b/Command/CKFinderDownloadCommand.php
@@ -129,6 +129,7 @@ class CKFinderDownloadCommand extends Command
         }
 
         $zip->extractTo($targetPublicPath, $zipEntries);
+        $zip->close();
 
         $fs = new Filesystem();
 


### PR DESCRIPTION
**Configuration**
* Symfony version: 3.4.29
* PHP Version: 7.3
* Windows 10 Pro

**Problem**
When running the command `ckfinder:download` the handle to the temporary Zip archive is never closed (this however depends on the implementation of `ZipArchive`) which is why it works for some configurations but not all. The proposed solution ensures the handle is always closed after the contents have been extracted to prevent `Filesystem::remove` from throwing an `IOException`.
