### PR TITLE
Fixed Symfony 5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/form": "~3.0|~4.0|~5.0",
         "symfony/console": "~3.0|~4.0|~5.0",
         "pimple/pimple": "~3.0",
-        "monolog/monolog": "~1.4,>=1.4.1",
+        "monolog/monolog": "~1.4|2.0",
         "league/flysystem": "^1.0.37",
         "league/flysystem-aws-s3-v3": "^1.0.13",
         "league/flysystem-cached-adapter": "^1.0.6"


### PR DESCRIPTION
Update monolog to 2.0 to allow installation on Symfony 5.0