### PR TITLE
Fixed Typo for monolog (Symfony 5 support)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/form": "~3.0|~4.0|~5.0",
         "symfony/console": "~3.0|~4.0|~5.0",
         "pimple/pimple": "~3.0",
-        "monolog/monolog": "~1.4|2.0",
+        "monolog/monolog": "~1.4|~2.0",
         "league/flysystem": "^1.0.37",
         "league/flysystem-aws-s3-v3": "^1.0.13",
         "league/flysystem-cached-adapter": "^1.0.6"


### PR DESCRIPTION
Forgot the "~" in front of 2.0 for monolog package. Symfony 5 installation should now be successful.