### PR TITLE
Add symfony 6 support

### DIFF
--- a/Command/CKFinderDownloadCommand.php
+++ b/Command/CKFinderDownloadCommand.php
@@ -53,7 +53,7 @@ class CKFinderDownloadCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $targetPublicPath = realpath(__DIR__ . '/../Resources/public');
 

--- a/DependencyInjection/CKSourceCKFinderExtension.php
+++ b/DependencyInjection/CKSourceCKFinderExtension.php
@@ -64,7 +64,7 @@ class CKSourceCKFinderExtension extends Extension implements PrependExtensionInt
     /**
      * @return string
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'ckfinder';
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): \Symfony\Component\Config\Definition\Builder\TreeBuilder
     {
         if (method_exists(TreeBuilder::class, 'getRootNode')) {
             $treeBuilder = new TreeBuilder('ckfinder');

--- a/Form/Type/CKFinderFileChooserType.php
+++ b/Form/Type/CKFinderFileChooserType.php
@@ -60,7 +60,7 @@ class CKFinderFileChooserType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }
@@ -68,7 +68,7 @@ class CKFinderFileChooserType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'ckfinder_file_chooser';
     }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": "^7.1|8.0.*|8.1.*",
         "symfony/framework-bundle": "^3.0|^4.0|^5.0|^6.0",
         "symfony/form": "^3.0|^4.0|^5.0|^6.0",
         "symfony/console": "^3.0|^4.0|^5.0|^6.0",
@@ -22,7 +22,7 @@
         "league/flysystem-cached-adapter": "^1.0.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "symfony/framework-bundle": "~3.0|~4.0|~5.0",
-        "symfony/form": "~3.0|~4.0|~5.0",
-        "symfony/console": "~3.0|~4.0|~5.0",
-        "symfony/mime": "~4.0|~5.0",
-        "pimple/pimple": "~3.0",
-        "monolog/monolog": "~1.4|~2.0",
+        "symfony/framework-bundle": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/form": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/console": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/mime": "^4.0|^5.0|^6.0",
+        "pimple/pimple": "^3.0",
+        "monolog/monolog": "^1.4|^2.0",
         "league/flysystem": "^1.1.8",
         "league/flysystem-aws-s3-v3": "^1.0.24",
         "league/flysystem-cached-adapter": "^1.0.7"


### PR DESCRIPTION
Not sure what else maybe required for symfony 6. But this some upgrade which are atleast required to support 6. Including cancelling PHP <7.1 support. As it would require to add nullable return types which were not supported before PHP 7.1.